### PR TITLE
Swap procedural hero renderer for illustrated panels

### DIFF
--- a/assets/panels/atomic-sentinel.svg
+++ b/assets/panels/atomic-sentinel.svg
@@ -1,0 +1,76 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 768">
+  <defs>
+    <linearGradient id="plating" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0%" stop-color="#ff9a42" />
+      <stop offset="50%" stop-color="#f25c05" />
+      <stop offset="100%" stop-color="#6c2100" />
+    </linearGradient>
+    <linearGradient id="reactorCore" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0%" stop-color="#ffe877" />
+      <stop offset="60%" stop-color="#ffc800" />
+      <stop offset="100%" stop-color="#ff5a00" />
+    </linearGradient>
+    <radialGradient id="visorFire" cx="0.5" cy="0.5" r="0.6">
+      <stop offset="0%" stop-color="#fff6a8" />
+      <stop offset="50%" stop-color="#ffd85a" />
+      <stop offset="100%" stop-color="#ff7c00" />
+    </radialGradient>
+  </defs>
+  <rect width="512" height="768" fill="none" />
+  <g stroke="#260900" stroke-width="3.2" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M168 130l-72 146c-24 56-20 98 26 142 46 44 102 66 134 66s88-22 134-66c46-44 50-86 26-142l-72-146" fill="url(#plating)" />
+    <path d="M256 124c-48 0-84 32-84 98 0 52 22 108 84 108s84-56 84-108c0-66-36-98-84-98z" fill="#311104" />
+    <path d="M188 212c24-28 42-40 68-40s44 12 68 40" fill="none" />
+    <path d="M176 304c30 24 52 36 80 36s50-12 80-36" fill="none" />
+    <path d="M206 358c-34 40-58 100-58 178 0 56 20 104 48 138 16 20 36 20 52 0 28-34 48-82 48-138 0-78-24-138-58-178" fill="#2e1204" />
+    <path d="M190 354c-26-6-66-34-112-86" fill="none" />
+    <path d="M322 354c26-6 66-34 112-86" fill="none" />
+    <path d="M198 234c-28-28-68-90-96-180l-70 54c-18 122 28 198 132 240" fill="#311104" />
+    <path d="M314 234c28-28 68-90 96-180l70 54c18 122-28 198-132 240" fill="#311104" />
+    <path d="M198 506c-18 56-20 94-8 138" fill="none" />
+    <path d="M314 506c18 56 20 94 8 138" fill="none" />
+    <path d="M214 546c20 40 34 60 42 60s22-20 42-60" fill="none" />
+  </g>
+  <g stroke="#ffec8c" stroke-width="3" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M158 270c36 8 66 8 98 0" />
+    <path d="M256 270c32 8 62 8 98 0" />
+    <path d="M170 334c28 12 52 18 82 18" />
+    <path d="M342 334c-30 12-54 18-82 18" />
+    <path d="M188 392c22 18 40 24 68 24" />
+    <path d="M324 392c-22 18-40 24-68 24" />
+    <path d="M204 448c18 20 32 28 52 28" />
+    <path d="M308 448c-18 20-32 28-52 28" />
+  </g>
+  <g stroke="#ffb347" stroke-width="2" stroke-linecap="round">
+    <path d="M210 178c18-12 32-16 46-16s28 4 46 16" />
+    <path d="M200 230c24-8 42-10 56-10s32 2 56 10" />
+    <path d="M188 288c28 12 50 16 68 16s40-4 68-16" />
+    <path d="M180 346c24 14 44 20 76 20s52-6 76-20" />
+    <path d="M172 402c18 14 38 22 64 22s46-8 64-22" />
+  </g>
+  <path d="M208 198c18-18 36-26 48-26s30 8 48 26c18 18 28 38 28 54s-10 30-28 30-38-10-48-10-30 10-48 10-28-14-28-30 10-36 28-54z" fill="#140600" stroke="#260900" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" />
+  <g fill="url(#visorFire)" stroke="#260900" stroke-width="3" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M212 214c0 18 12 26 44 26s44-8 44-26-12-26-44-26-44 8-44 26z" />
+    <path d="M224 214c0 8 6 12 20 12s20-4 20-12-6-12-20-12-20 4-20 12z" fill="#ffe89a" />
+    <path d="M288 214c0 8 6 12 20 12s20-4 20-12-6-12-20-12-20 4-20 12z" fill="#ffe89a" />
+  </g>
+  <g fill="url(#reactorCore)" stroke="#260900" stroke-width="3" stroke-linecap="round" stroke-linejoin="round">
+    <circle cx="256" cy="306" r="48" />
+    <path d="M256 258l-16 46 16 12 16-12z" />
+    <path d="M256 354l-16-46 16-12 16 12z" />
+  </g>
+  <g stroke="#ffcf66" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" opacity="0.8">
+    <path d="M120 330l-58-18" />
+    <path d="M112 374l-58 6" />
+    <path d="M392 330l58-18" />
+    <path d="M400 374l58 6" />
+    <path d="M150 420l-48 26" />
+    <path d="M362 420l48 26" />
+  </g>
+  <g stroke="#ff8a2f" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" opacity="0.7">
+    <path d="M142 164l-56-48" />
+    <path d="M138 208l-64-26" />
+    <path d="M370 164l56-48" />
+    <path d="M374 208l64-26" />
+  </g>
+</svg>

--- a/assets/panels/cosmic-guardian.svg
+++ b/assets/panels/cosmic-guardian.svg
@@ -1,0 +1,58 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 768">
+  <defs>
+    <linearGradient id="capeGlow" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0%" stop-color="#3a5bff" stop-opacity="0.85" />
+      <stop offset="60%" stop-color="#192083" stop-opacity="0.9" />
+      <stop offset="100%" stop-color="#05051c" stop-opacity="0.95" />
+    </linearGradient>
+    <linearGradient id="armorSheen" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0%" stop-color="#d9e2ff" />
+      <stop offset="45%" stop-color="#6d7cf6" />
+      <stop offset="100%" stop-color="#1c1f5a" />
+    </linearGradient>
+    <radialGradient id="cosmicCore" cx="0.5" cy="0.4" r="0.6">
+      <stop offset="0%" stop-color="#fff8c8" />
+      <stop offset="40%" stop-color="#ffe06a" />
+      <stop offset="100%" stop-color="#d24fdb" />
+    </radialGradient>
+    <filter id="inkBlur" x="-5%" y="-5%" width="110%" height="110%">
+      <feGaussianBlur in="SourceGraphic" stdDeviation="0.9" />
+    </filter>
+  </defs>
+  <rect width="512" height="768" fill="none" />
+  <g stroke="#060611" stroke-linecap="round" stroke-linejoin="round" stroke-width="3">
+    <path d="M256 130c-46 0-82 30-94 86l-42 214c28 68 87 104 136 104s108-36 136-104l-42-214c-12-56-48-86-94-86z" fill="url(#armorSheen)" />
+    <path d="M162 216c24-44 58-66 94-66s70 22 94 66l36 188c-18 54-72 88-130 88s-112-34-130-88l36-188z" fill="none" />
+    <path d="M256 116c-12 0-24 10-24 34 0 28 12 54 24 54s24-26 24-54c0-24-12-34-24-34z" fill="#060611" />
+    <path d="M208 180c18-10 32-14 48-14s30 4 48 14" fill="none" />
+    <path d="M214 210c12-6 24-10 42-10s30 4 42 10" fill="none" />
+    <path d="M240 254c6-6 10-8 16-8s10 2 16 8" fill="none" />
+    <path d="M178 424c24 20 48 30 78 30s54-10 78-30" fill="none" />
+    <path d="M154 344l-20 76c18 46 60 72 122 72s104-26 122-72l-20-76c-26 28-60 42-102 42s-76-14-102-42z" fill="none" />
+    <path d="M188 502c-18 28-32 74-26 110l10 68c34 14 64 22 84 22s50-8 84-22l10-68c6-36-8-82-26-110" fill="#111226" />
+    <path d="M160 624c40 24 64 34 96 34s56-10 96-34" fill="none" />
+    <path d="M156 286l-64 74c-12 24-12 46 16 66 32 24 60 32 86 30" fill="none" />
+    <path d="M356 286l64 74c12 24 12 46-16 66-32 24-60 32-86 30" fill="none" />
+    <path d="M198 188c-22-26-38-56-44-94l-58 38c-18 66 0 120 68 164" fill="url(#capeGlow)" />
+    <path d="M314 188c22-26 38-56 44-94l58 38c18 66 0 120-68 164" fill="url(#capeGlow)" />
+    <path d="M256 192c-22 0-44 20-48 52-4 34 14 82 48 82s52-48 48-82c-4-32-26-52-48-52z" fill="#232559" />
+    <path d="M230 210c10 12 16 18 26 18s16-6 26-18" fill="none" />
+    <path d="M240 246h32" fill="none" />
+    <path d="M256 302c-16 0-28 14-28 34 0 22 12 36 28 36s28-14 28-36c0-20-12-34-28-34z" fill="#0c0f2f" />
+  </g>
+  <g stroke="#060611" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+    <path d="M164 468c-8 28-14 76-6 114" fill="none" />
+    <path d="M348 468c8 28 14 76 6 114" fill="none" />
+    <path d="M208 548c12 26 30 40 48 40s36-14 48-40" fill="none" />
+    <path d="M184 356c-26 0-62-12-90-42" fill="none" />
+    <path d="M328 356c26 0 62-12 90-42" fill="none" />
+    <path d="M210 150c10 10 26 16 46 16s36-6 46-16" fill="none" />
+  </g>
+  <circle cx="256" cy="284" r="54" fill="url(#cosmicCore)" opacity="0.72" />
+  <g stroke="#f8f2ff" stroke-linecap="round" stroke-width="2" opacity="0.7" filter="url(#inkBlur)">
+    <path d="M118 212c28 12 50 14 74 6" />
+    <path d="M394 212c-28 12-50 14-74 6" />
+    <path d="M176 320c18 16 44 24 80 24s62-8 80-24" />
+    <path d="M188 404c14 18 34 26 68 26s54-8 68-26" />
+  </g>
+</svg>

--- a/assets/panels/mythic-sorcerer.svg
+++ b/assets/panels/mythic-sorcerer.svg
@@ -1,0 +1,76 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 768">
+  <defs>
+    <radialGradient id="robeGlow" cx="0.5" cy="0.2" r="0.8">
+      <stop offset="0%" stop-color="#f6e7ff" />
+      <stop offset="50%" stop-color="#8f60ff" />
+      <stop offset="100%" stop-color="#2c0f60" />
+    </radialGradient>
+    <radialGradient id="orbLight" cx="0.5" cy="0.5" r="0.5">
+      <stop offset="0%" stop-color="#fff7d6" />
+      <stop offset="50%" stop-color="#ffd05c" />
+      <stop offset="100%" stop-color="#ff5c8d" />
+    </radialGradient>
+    <linearGradient id="capeGradient" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0%" stop-color="#c7a6ff" />
+      <stop offset="60%" stop-color="#6732d6" />
+      <stop offset="100%" stop-color="#1f0c44" />
+    </linearGradient>
+  </defs>
+  <rect width="512" height="768" fill="none" />
+  <g stroke="#110524" stroke-width="3" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M214 132l-86 112c-26 40-34 86 14 128 48 42 88 60 114 60s66-18 114-60c48-42 40-88 14-128l-86-112" fill="url(#capeGradient)" />
+    <path d="M256 122c-42 0-70 32-70 88 0 48 28 102 70 102s70-54 70-102c0-56-28-88-70-88z" fill="url(#robeGlow)" />
+    <path d="M194 208c20-28 38-40 62-40s42 12 62 40" fill="none" />
+    <path d="M188 288c24 20 46 30 68 30s44-10 68-30" fill="none" />
+    <path d="M206 344c-26 32-44 74-44 134 0 70 24 118 54 142 18 14 40 14 60 0 30-24 54-72 54-142 0-60-18-102-44-134" fill="#2d124f" />
+    <path d="M184 342c-20-4-52-28-86-72" fill="none" />
+    <path d="M328 342c20-4 52-28 86-72" fill="none" />
+    <path d="M194 216c-24-24-52-74-72-150l-60 48c-20 98 12 164 92 200" fill="#1a0838" />
+    <path d="M318 216c24-24 52-74 72-150l60 48c20 98-12 164-92 200" fill="#1a0838" />
+    <path d="M190 472c-16 48-18 82-6 122" fill="none" />
+    <path d="M322 472c16 48 18 82 6 122" fill="none" />
+    <path d="M212 504c20 34 32 48 44 48s24-14 44-48" fill="none" />
+  </g>
+  <g stroke="#f8edff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M160 230c42 12 76 16 96 16s54-4 96-16" />
+    <path d="M162 308c28 18 58 26 94 26s66-8 94-26" />
+    <path d="M176 390c26 22 50 32 80 32s54-10 80-32" />
+    <path d="M188 456c18 24 38 36 68 36s50-12 68-36" />
+  </g>
+  <g stroke="#ffd971" stroke-width="2" stroke-linecap="round">
+    <path d="M214 182c14-8 26-10 42-10s28 2 42 10" />
+    <path d="M200 246c22-6 42-8 56-8s34 2 56 8" />
+    <path d="M190 314c24 10 46 14 66 14s42-4 66-14" />
+    <path d="M180 382c22 16 44 24 76 24s54-8 76-24" />
+    <path d="M172 446c18 18 38 28 68 28s50-10 68-28" />
+  </g>
+  <g stroke="#ffb7d6" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" opacity="0.9">
+    <path d="M128 188c16 6 32 6 52-2" />
+    <path d="M384 188c-16 6-32 6-52-2" />
+    <path d="M142 256c18 10 34 12 54 4" />
+    <path d="M370 256c-18 10-34 12-54 4" />
+  </g>
+  <g stroke="#fff6d8" stroke-width="2" stroke-linecap="round" stroke-dasharray="8 8">
+    <path d="M256 84l-10 48" />
+    <path d="M256 84l10 48" />
+    <path d="M188 96l32 46" />
+    <path d="M324 96l-32 46" />
+  </g>
+  <g fill="url(#orbLight)" stroke="#110524" stroke-width="3" stroke-linecap="round" stroke-linejoin="round">
+    <circle cx="256" cy="236" r="42" />
+    <path d="M256 194l-10 26 10 10 10-10z" />
+    <path d="M256 278l-10-26 10-10 10 10z" />
+  </g>
+  <g stroke="#ffd05c" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" opacity="0.8">
+    <path d="M136 422l-60-20" />
+    <path d="M130 460l-60 8" />
+    <path d="M376 422l60-20" />
+    <path d="M382 460l60 8" />
+  </g>
+  <g stroke="#dcd0ff" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" opacity="0.6">
+    <path d="M94 338l68 14" />
+    <path d="M418 338l-68 14" />
+    <path d="M108 380l74 12" />
+    <path d="M404 380l-74 12" />
+  </g>
+</svg>

--- a/assets/panels/neon-rogue.svg
+++ b/assets/panels/neon-rogue.svg
@@ -1,0 +1,64 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 768">
+  <defs>
+    <linearGradient id="suitNeon" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0%" stop-color="#0b1b3d" />
+      <stop offset="40%" stop-color="#162b73" />
+      <stop offset="100%" stop-color="#0f0c29" />
+    </linearGradient>
+    <linearGradient id="speedLines" x1="0" x2="1" y1="0" y2="0">
+      <stop offset="0%" stop-color="#0ff0ff" stop-opacity="0" />
+      <stop offset="40%" stop-color="#00d5ff" stop-opacity="0.5" />
+      <stop offset="100%" stop-color="#ff2ca8" stop-opacity="0.9" />
+    </linearGradient>
+    <radialGradient id="visorGlow" cx="0.5" cy="0.5" r="0.7">
+      <stop offset="0%" stop-color="#00f6ff" />
+      <stop offset="60%" stop-color="#00b7ff" />
+      <stop offset="100%" stop-color="#04174a" />
+    </radialGradient>
+  </defs>
+  <rect width="512" height="768" fill="none" />
+  <g stroke="#050211" stroke-width="3" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M192 132l-80 126c-18 32-24 70 10 102 34 34 82 48 124 48s90-14 124-48c34-32 28-70 10-102l-80-126" fill="url(#suitNeon)" />
+    <path d="M256 118c-44 0-72 30-72 72s28 86 72 86 72-44 72-86-28-72-72-72z" fill="#0c1330" />
+    <path d="M198 180c20-14 40-20 58-20s38 6 58 20" fill="none" />
+    <path d="M190 264c28 20 46 28 66 28s38-8 66-28" fill="none" />
+    <path d="M214 318l-40 168c18 44 46 76 82 94s66 18 92 0l-40-262" fill="#121438" />
+    <path d="M298 318l40 168c-18 44-46 76-82 94s-66 18-92 0l40-262" fill="none" />
+    <path d="M178 442l-52 74c-12 22-8 50 38 78 44 26 84 36 120 36s76-10 120-36c46-28 50-56 38-78l-52-74" fill="none" />
+    <path d="M178 206c-26-16-54-54-74-114l-60 50c-14 84 18 140 92 170" fill="#0c0f22" />
+    <path d="M334 206c26-16 54-54 74-114l60 50c14 84-18 140-92 170" fill="#0c0f22" />
+    <path d="M156 308c-20-2-50-20-84-56" fill="none" />
+    <path d="M356 308c20-2 50-20 84-56" fill="none" />
+    <path d="M210 500c-14 40-18 70-8 110" fill="none" />
+    <path d="M302 500c14 40 18 70 8 110" fill="none" />
+  </g>
+  <g stroke="#08f8ff" stroke-width="3" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M118 254c48 10 92 10 138 0" />
+    <path d="M256 380c36 0 64-8 88-24" />
+    <path d="M200 378c16 18 30 30 56 30" />
+    <path d="M164 472c28 26 58 38 92 38" />
+    <path d="M324 472c-28 26-58 38-92 38" />
+  </g>
+  <g stroke="#ff2fa6" stroke-width="2" stroke-linecap="round">
+    <path d="M152 168c32-6 56-6 80 0" />
+    <path d="M216 224c24-4 40-4 64 0" />
+    <path d="M202 288c20 4 36 4 54 0" />
+    <path d="M184 350c24 10 46 14 72 14" />
+    <path d="M168 414c18 16 40 24 68 24" />
+    <path d="M350 414c-18 16-40 24-68 24" />
+  </g>
+  <path d="M208 196c18-16 36-24 48-24s30 8 48 24c18 18 30 40 30 56s-10 34-30 34-40-12-48-12-28 12-48 12-30-18-30-34 12-38 30-56z" fill="url(#visorGlow)" stroke="#050211" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" />
+  <g stroke="#00f0ff" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" opacity="0.9">
+    <path d="M54 154l108 22" />
+    <path d="M18 214l160 28" />
+    <path d="M32 276l176 22" />
+    <path d="M30 340l166 20" />
+  </g>
+  <g stroke="#ff2ca8" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" opacity="0.9">
+    <path d="M458 154l-108 22" />
+    <path d="M494 214l-160 28" />
+    <path d="M480 276l-176 22" />
+    <path d="M482 340l-166 20" />
+  </g>
+  <rect x="90" y="548" width="332" height="124" fill="url(#speedLines)" opacity="0.32" stroke="#050211" stroke-width="2" stroke-linejoin="round" />
+</svg>

--- a/assets/panels/shadow-operative.svg
+++ b/assets/panels/shadow-operative.svg
@@ -1,0 +1,68 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 768">
+  <defs>
+    <linearGradient id="shadowSuit" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0%" stop-color="#1c2438" />
+      <stop offset="50%" stop-color="#101623" />
+      <stop offset="100%" stop-color="#06080f" />
+    </linearGradient>
+    <linearGradient id="cloakEdge" x1="0" x2="1" y1="0" y2="0">
+      <stop offset="0%" stop-color="#27334a" />
+      <stop offset="50%" stop-color="#121926" />
+      <stop offset="100%" stop-color="#1c1f2e" />
+    </linearGradient>
+    <radialGradient id="gogglesGlow" cx="0.5" cy="0.5" r="0.6">
+      <stop offset="0%" stop-color="#ffe880" />
+      <stop offset="50%" stop-color="#ffd148" />
+      <stop offset="100%" stop-color="#ff8c1c" />
+    </radialGradient>
+  </defs>
+  <rect width="512" height="768" fill="none" />
+  <g stroke="#04060b" stroke-width="3" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M178 134l-96 174c-18 44-12 82 32 116s90 50 142 50 98-16 142-50 50-72 32-116l-96-174" fill="url(#cloakEdge)" />
+    <path d="M256 128c-50 0-82 30-82 94 0 48 18 98 82 98s82-50 82-98c0-64-32-94-82-94z" fill="url(#shadowSuit)" />
+    <path d="M192 220c22-28 38-40 64-40s42 12 64 40" fill="none" />
+    <path d="M182 310c28 24 50 36 74 36s46-12 74-36" fill="none" />
+    <path d="M204 360c-32 42-52 100-52 172 0 56 20 102 48 130 14 14 30 14 44 0 28-28 48-74 48-130 0-72-20-130-52-172" fill="#0a0f1c" />
+    <path d="M190 354c-24-6-60-32-100-80" fill="none" />
+    <path d="M322 354c24-6 60-32 100-80" fill="none" />
+    <path d="M198 232c-26-26-60-82-84-162l-66 50c-18 108 22 180 118 220" fill="#070b14" />
+    <path d="M314 232c26-26 60-82 84-162l66 50c18 108-22 180-118 220" fill="#070b14" />
+    <path d="M198 488c-18 50-18 86-8 128" fill="none" />
+    <path d="M314 488c18 50 18 86 8 128" fill="none" />
+    <path d="M214 524c18 38 30 56 42 56s24-18 42-56" fill="none" />
+  </g>
+  <g stroke="#1b2435" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M142 278c32 8 60 8 84 0" />
+    <path d="M286 278c24 8 52 8 84 0" />
+    <path d="M154 338c28 14 52 18 78 18" />
+    <path d="M358 338c-26 14-50 18-78 18" />
+    <path d="M170 400c24 18 44 24 70 24" />
+    <path d="M342 400c-24 18-44 24-70 24" />
+    <path d="M188 460c16 20 32 30 56 30" />
+    <path d="M324 460c-16 20-32 30-56 30" />
+  </g>
+  <path d="M208 196c18-16 36-22 48-22s30 6 48 22c18 18 28 36 28 52s-10 30-28 30-38-10-48-10-30 10-48 10-28-14-28-30 10-34 28-52z" fill="#101c2a" stroke="#04060b" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" />
+  <g stroke="#ffe066" stroke-width="4" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M224 204c12-10 20-14 32-14s20 4 32 14" />
+    <path d="M220 238c16-8 24-10 36-10s20 2 36 10" />
+  </g>
+  <g fill="url(#gogglesGlow)" stroke="#04060b" stroke-width="3" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M208 226c0 16 14 26 48 26s48-10 48-26-14-26-48-26-48 10-48 26z" />
+    <path d="M212 226c0 8 6 12 20 12s20-4 20-12-6-12-20-12-20 4-20 12z" fill="#ffe066" />
+    <path d="M280 226c0 8 6 12 20 12s20-4 20-12-6-12-20-12-20 4-20 12z" fill="#ffe066" />
+  </g>
+  <g stroke="#2c3650" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" opacity="0.6">
+    <path d="M104 340l-56-16" />
+    <path d="M100 380l-56 4" />
+    <path d="M408 340l56-16" />
+    <path d="M412 380l56 4" />
+    <path d="M128 420l-44 20" />
+    <path d="M384 420l44 20" />
+  </g>
+  <g stroke="#0d1422" stroke-width="2" stroke-linecap="round" stroke-dasharray="10 12" opacity="0.8">
+    <path d="M170 126c12 36 24 58 34 70" />
+    <path d="M342 126c-12 36-24 58-34 70" />
+    <path d="M128 502c24 26 46 40 64 46" />
+    <path d="M384 502c-24 26-46 40-64 46" />
+  </g>
+</svg>

--- a/index.html
+++ b/index.html
@@ -24,6 +24,18 @@
       <section class="controls">
         <h2>Character Profile</h2>
         <form id="character-form">
+          <label class="field preset-field">
+            <span>Visual Preset</span>
+            <select id="preset-select" name="preset">
+              <option value="custom">Custom Mix</option>
+              <option value="cosmic-guardian">Cosmic Guardian</option>
+              <option value="neon-rogue">Neon Rogue</option>
+              <option value="mythic-sorcerer">Mythic Sorcerer</option>
+              <option value="shadow-operative">Shadow Operative</option>
+              <option value="atomic-sentinel">Atomic Sentinel</option>
+            </select>
+          </label>
+
           <div class="form-grid">
             <label class="field">
               <span>Hero Name</span>
@@ -137,6 +149,7 @@
         <article class="character-sheet" id="character-sheet">
           <h3 id="sheet-name">Your character awaits...</h3>
           <p id="sheet-summary">Choose traits and craft a backstory to bring them to life.</p>
+          <p id="sheet-theme" class="sheet-theme"></p>
           <p id="sheet-power"></p>
           <div id="sheet-traits" class="traits-list"></div>
           <p id="sheet-backstory"></p>

--- a/script.js
+++ b/script.js
@@ -2,41 +2,304 @@ const form = document.getElementById("character-form");
 const canvas = document.getElementById("hero-canvas");
 const ctx = canvas.getContext("2d");
 
+const presetSelect = document.getElementById("preset-select");
 const sheetName = document.getElementById("sheet-name");
 const sheetSummary = document.getElementById("sheet-summary");
 const sheetPower = document.getElementById("sheet-power");
 const sheetTraits = document.getElementById("sheet-traits");
 const sheetBackstory = document.getElementById("sheet-backstory");
+const sheetTheme = document.getElementById("sheet-theme");
+
+const PRESETS = {
+  custom: {
+    label: "Custom Mix",
+    tagline: "",
+  },
+  "cosmic-guardian": {
+    label: "Cosmic Guardian",
+    name: "Starlance Prime",
+    gender: "Non-binary",
+    alignment: "Hero",
+    origin: "Cosmic Wanderer",
+    specialty: "Mystic",
+    height: "Tall",
+    traits: ["Compassionate", "Strategic", "Stoic"],
+    primaryColor: "#314dff",
+    secondaryColor: "#ff5d9d",
+    accentColor: "#f4ff8d",
+    power: "Solar-sung Singularity Lance",
+    backstory:
+      "Forged within the heart of a dying star, Starlance Prime patrols the astral planes to keep the cosmic lattice from unraveling.",
+    tagline: "Sentinel of the Celestial Spires",
+    sfx: "ASTRAL!",
+    bubble: "THE CONSTELLATIONS ANSWER MY CALL!",
+    heroArt: {
+      src: "assets/panels/cosmic-guardian.svg",
+      frame: { heightRatio: 0.78, baseline: 0.9, centerX: 0.5 },
+      bubble: {
+        anchorX: 0.78,
+        anchorY: 0.12,
+        widthRatio: 0.48,
+        tailX: 0.62,
+        tailY: 0.34,
+      },
+      sfx: { anchorX: 0.24, anchorY: 0.26, radiusRatio: 0.2, rotation: -0.18 },
+    },
+  },
+  "neon-rogue": {
+    label: "Neon Rogue",
+    name: "Overclock",
+    gender: "Genderfluid",
+    alignment: "Anti-hero",
+    origin: "Technological Construct",
+    specialty: "Speedster",
+    height: "Average",
+    traits: ["Chaotic", "Strategic", "Charismatic"],
+    primaryColor: "#11a0ff",
+    secondaryColor: "#0c032c",
+    accentColor: "#ff0078",
+    power: "Photon-split Velocity Drives",
+    backstory:
+      "After merging with a black market AI, Overclock races through the megacity's data-streams to redistribute stolen futures.",
+    tagline: "Streak of the Midnight Megacity",
+    sfx: "VRRRRM!",
+    bubble: "LIGHTS OUT FOR THE GRIDLORDS!",
+    heroArt: {
+      src: "assets/panels/neon-rogue.svg",
+      frame: { heightRatio: 0.76, baseline: 0.9, centerX: 0.52 },
+      bubble: {
+        anchorX: 0.76,
+        anchorY: 0.1,
+        widthRatio: 0.5,
+        tailX: 0.58,
+        tailY: 0.32,
+      },
+      sfx: { anchorX: 0.26, anchorY: 0.2, radiusRatio: 0.22, rotation: -0.12 },
+    },
+  },
+  "mythic-sorcerer": {
+    label: "Mythic Sorcerer",
+    name: "Eldra Nyx",
+    gender: "Female",
+    alignment: "Hero",
+    origin: "Interdimensional",
+    specialty: "Mystic",
+    height: "Average",
+    traits: ["Compassionate", "Charismatic"],
+    primaryColor: "#6f2dff",
+    secondaryColor: "#f6a13b",
+    accentColor: "#ffe29d",
+    power: "Chrono-etched Sigil Weaving",
+    backstory:
+      "Eldra Nyx slipped between realms to bind timefractures with rune-sung incantations, striking bargains with forgotten pantheons.",
+    tagline: "Oracle of the Everwoven",
+    sfx: "SHIMMER!",
+    bubble: "BY THE THREADS OF FATE, BE STILL!",
+    heroArt: {
+      src: "assets/panels/mythic-sorcerer.svg",
+      frame: { heightRatio: 0.8, baseline: 0.92, centerX: 0.48 },
+      bubble: {
+        anchorX: 0.74,
+        anchorY: 0.14,
+        widthRatio: 0.5,
+        tailX: 0.56,
+        tailY: 0.38,
+      },
+      sfx: { anchorX: 0.3, anchorY: 0.28, radiusRatio: 0.24, rotation: -0.2 },
+    },
+  },
+  "shadow-operative": {
+    label: "Shadow Operative",
+    name: "Nocturne Wraith",
+    gender: "Male",
+    alignment: "Vigilante",
+    origin: "Earth-born",
+    specialty: "Stealth Operative",
+    height: "Tall",
+    traits: ["Stoic", "Strategic"],
+    primaryColor: "#161d2b",
+    secondaryColor: "#c7d1ff",
+    accentColor: "#ffe066",
+    power: "Umbral Phase Step",
+    backstory:
+      "An ex-intelligence asset, Nocturne Wraith vanished from public record and now hunts the corrupt underbelly beneath storm-soaked skylines.",
+    tagline: "Whisper in the Rain",
+    sfx: "SLNK!",
+    bubble: "YOUR SHADOWS BETRAY YOU.",
+    heroArt: {
+      src: "assets/panels/shadow-operative.svg",
+      frame: { heightRatio: 0.82, baseline: 0.92, centerX: 0.5 },
+      bubble: {
+        anchorX: 0.76,
+        anchorY: 0.18,
+        widthRatio: 0.48,
+        tailX: 0.58,
+        tailY: 0.4,
+      },
+      sfx: { anchorX: 0.26, anchorY: 0.26, radiusRatio: 0.22, rotation: -0.16 },
+    },
+  },
+  "atomic-sentinel": {
+    label: "Atomic Sentinel",
+    name: "Voltarion-6",
+    gender: "Unspecified",
+    alignment: "Hero",
+    origin: "Mutant",
+    specialty: "Defender",
+    height: "Towering",
+    traits: ["Stoic", "Compassionate"],
+    primaryColor: "#f25c05",
+    secondaryColor: "#313131",
+    accentColor: "#ffec3d",
+    power: "Planetary Core Overcharge",
+    backstory:
+      "Born from an experimental reactor breach, Voltarion-6 channels tectonic force to shield cities from apocalyptic fallout.",
+    tagline: "Bulwark of the Radiant Dawn",
+    sfx: "BRRRAK-KOOM!",
+    bubble: "THE CORE BURNS FOR THE PEOPLE!",
+    heroArt: {
+      src: "assets/panels/atomic-sentinel.svg",
+      frame: { heightRatio: 0.82, baseline: 0.92, centerX: 0.5 },
+      bubble: {
+        anchorX: 0.78,
+        anchorY: 0.12,
+        widthRatio: 0.5,
+        tailX: 0.62,
+        tailY: 0.34,
+      },
+      sfx: { anchorX: 0.24, anchorY: 0.24, radiusRatio: 0.22, rotation: -0.14 },
+    },
+  },
+};
+
+const heroArtCache = new Map();
 
 form.addEventListener("submit", (event) => {
   event.preventDefault();
-  const formData = new FormData(form);
+  renderHero();
+});
 
-  const traits = formData.getAll("traits");
-  const heroData = {
-    name: formData.get("name")?.trim() || "Unnamed Legend",
-    gender: formData.get("gender"),
-    alignment: formData.get("alignment"),
-    origin: formData.get("origin"),
-    specialty: formData.get("specialty"),
-    height: formData.get("height"),
-    traits,
-    primaryColor: formData.get("primaryColor"),
-    secondaryColor: formData.get("secondaryColor"),
-    accentColor: formData.get("accentColor"),
-    power: formData.get("power")?.trim(),
-    backstory: formData.get("backstory")?.trim(),
-  };
+presetSelect.addEventListener("change", () => {
+  const key = presetSelect.value;
+  if (key === "custom") {
+    renderHero();
+    return;
+  }
+  applyPresetToForm(key);
+  renderHero();
+});
 
+function renderHero() {
+  const heroData = collectHeroData();
   updateSheet(heroData);
   drawHero(heroData);
-});
+}
+
+function resolveHeroArtEntry(hero) {
+  const preset = PRESETS[hero.presetKey];
+  const config = hero.heroArt || preset?.heroArt;
+  if (!config?.src) {
+    return { status: "missing", image: null, config: null };
+  }
+
+  let entry = heroArtCache.get(config.src);
+  if (!entry) {
+    const image = new Image();
+    entry = { status: "loading", image, config };
+    heroArtCache.set(config.src, entry);
+    image.addEventListener("load", () => {
+      entry.status = "loaded";
+      if (presetSelect.value === hero.presetKey) {
+        window.requestAnimationFrame(() => renderHero());
+      }
+    });
+    image.addEventListener("error", () => {
+      entry.status = "error";
+    });
+    image.src = config.src;
+  }
+
+  entry.config = config;
+  return entry;
+}
+
+function collectHeroData() {
+  const formData = new FormData(form);
+  const traits = formData.getAll("traits");
+  const presetKey = presetSelect.value || "custom";
+  const presetMeta = PRESETS[presetKey] || PRESETS.custom;
+
+  return {
+    name: formData.get("name")?.trim() || presetMeta.name || "Unnamed Legend",
+    gender: formData.get("gender") || presetMeta.gender || "Unspecified",
+    alignment: formData.get("alignment") || presetMeta.alignment || "Hero",
+    origin: formData.get("origin") || presetMeta.origin || "Earth-born",
+    specialty: formData.get("specialty") || presetMeta.specialty || "Defender",
+    height: formData.get("height") || presetMeta.height || "Average",
+    traits,
+    primaryColor: formData.get("primaryColor") || presetMeta.primaryColor || "#2c4bff",
+    secondaryColor: formData.get("secondaryColor") || presetMeta.secondaryColor || "#ff3d6a",
+    accentColor: formData.get("accentColor") || presetMeta.accentColor || "#fdd835",
+    power: formData.get("power")?.trim() || presetMeta.power || "",
+    backstory: formData.get("backstory")?.trim() || presetMeta.backstory || "",
+    presetKey,
+    presetLabel: presetMeta.label,
+    presetTagline: presetMeta.tagline,
+    presetSfx: presetMeta.sfx,
+    presetBubble: presetMeta.bubble,
+    heroArt: presetMeta.heroArt || null,
+  };
+}
+
+function applyPresetToForm(key) {
+  const preset = PRESETS[key];
+  if (!preset) {
+    return;
+  }
+
+  const setValue = (name, value) => {
+    const field = form.elements.namedItem(name);
+    if (!field || typeof value === "undefined") {
+      return;
+    }
+    if (field instanceof HTMLInputElement || field instanceof HTMLTextAreaElement) {
+      field.value = value;
+    } else if (field instanceof HTMLSelectElement) {
+      field.value = value;
+    }
+  };
+
+  setValue("name", preset.name || "");
+  setValue("gender", preset.gender || "Unspecified");
+  setValue("alignment", preset.alignment || "Hero");
+  setValue("origin", preset.origin || "Earth-born");
+  setValue("specialty", preset.specialty || "Defender");
+  setValue("height", preset.height || "Average");
+  setValue("primaryColor", preset.primaryColor || "#2c4bff");
+  setValue("secondaryColor", preset.secondaryColor || "#ff3d6a");
+  setValue("accentColor", preset.accentColor || "#fdd835");
+  setValue("power", preset.power || "");
+  setValue("backstory", preset.backstory || "");
+
+  const traitInputs = form.querySelectorAll('input[name="traits"]');
+  traitInputs.forEach((input) => {
+    input.checked = !!preset.traits?.includes(input.value);
+  });
+}
 
 function updateSheet(hero) {
   sheetName.textContent = hero.name;
 
   const summary = `${hero.alignment} ${hero.origin.toLowerCase()} ${hero.specialty.toLowerCase()} (${hero.gender.toLowerCase()}, ${hero.height.toLowerCase()} build)`;
   sheetSummary.textContent = capitalizeSentences(summary);
+
+  if (hero.presetKey !== "custom" && (hero.presetTagline || hero.presetLabel)) {
+    sheetTheme.textContent = (hero.presetTagline || hero.presetLabel).toUpperCase();
+    sheetTheme.style.display = "block";
+  } else {
+    sheetTheme.textContent = "";
+    sheetTheme.style.display = "none";
+  }
 
   sheetPower.textContent = hero.power ? `Signature Power: ${hero.power}` : "";
 
@@ -70,53 +333,239 @@ function drawHero(hero) {
 
   ctx.clearRect(0, 0, width, canvasHeight);
 
-  drawBackdrop(ctx, width, canvasHeight, hero);
-
   const figureHeight = mapHeight(height, canvasHeight);
   const centerX = width / 2;
   const baseY = canvasHeight * 0.84;
   const metrics = createFigureMetrics(centerX, baseY, figureHeight);
+  const artEntry = resolveHeroArtEntry(hero);
+  const artConfigured = !!artEntry.config;
+  const artLoaded = artConfigured && artEntry.status === "loaded";
+  const artFrame = artConfigured
+    ? computeHeroArtFrame(artEntry.config, width, canvasHeight, artLoaded ? artEntry.image : null)
+    : null;
 
-  drawGroundShadow(ctx, metrics);
+  drawBackdrop(ctx, width, canvasHeight, hero);
+  drawBackdropLinework(ctx, width, canvasHeight, hero, metrics);
 
-  if (alignment === "Hero" || alignment === "Anti-hero") {
-    drawDrapedCape(ctx, metrics, secondaryColor, alignment === "Anti-hero");
-  } else if (alignment === "Villain") {
-    drawDrapedCape(ctx, metrics, darkenColor(secondaryColor, 35), true);
+  drawPresetBackdrop(ctx, width, canvasHeight, hero, metrics);
+
+  if (artFrame) {
+    drawGroundShadow(ctx, metrics, {
+      centerX: artFrame.centerX,
+      baseY: artFrame.baselineY,
+      width: artFrame.width * 0.32,
+      height: artFrame.height * 0.16,
+    });
+  } else {
+    drawGroundShadow(ctx, metrics);
   }
 
-  drawLeg(ctx, metrics, hero, "left");
-  drawLeg(ctx, metrics, hero, "right");
+  if (artLoaded) {
+    drawIllustratedHero(ctx, hero, artEntry.image, artFrame);
+  } else if (artConfigured && artEntry.status === "loading") {
+    drawIllustratedPlaceholder(ctx, hero, artFrame || metrics);
+  } else {
+    if (alignment === "Hero" || alignment === "Anti-hero") {
+      drawDrapedCape(ctx, metrics, secondaryColor, alignment === "Anti-hero");
+    } else if (alignment === "Villain") {
+      drawDrapedCape(ctx, metrics, darkenColor(secondaryColor, 35), true);
+    }
 
-  drawTorso(ctx, metrics, hero);
-  drawArm(ctx, metrics, hero, "left");
-  drawArm(ctx, metrics, hero, "right");
-  drawHair(ctx, metrics, hero);
-  drawHeadAndFace(ctx, metrics, hero);
-  drawCostumeHighlights(ctx, metrics, hero);
-  inkMuscleContours(ctx, metrics, hero);
+    drawLeg(ctx, metrics, hero, "left");
+    drawLeg(ctx, metrics, hero, "right");
 
-  if (specialty === "Mystic") {
-    drawMysticSigils(ctx, metrics, accentColor);
-  } else if (specialty === "Speedster") {
-    drawSpeedBurst(ctx, metrics, accentColor);
-  } else if (specialty === "Stealth") {
-    drawStealthShadow(ctx, metrics, secondaryColor);
+    drawTorso(ctx, metrics, hero);
+    drawArm(ctx, metrics, hero, "left");
+    drawArm(ctx, metrics, hero, "right");
+    drawHair(ctx, metrics, hero);
+    drawHeadAndFace(ctx, metrics, hero);
+    drawCostumeHighlights(ctx, metrics, hero);
+    inkMuscleContours(ctx, metrics, hero);
+    drawFigureSketchLines(ctx, metrics);
+
+    if (specialty === "Mystic") {
+      drawMysticSigils(ctx, metrics, accentColor);
+    } else if (specialty === "Speedster") {
+      drawSpeedBurst(ctx, metrics, accentColor);
+    } else if (specialty === "Stealth") {
+      drawStealthShadow(ctx, metrics, secondaryColor);
+    }
+
+    if (power) {
+      drawPowerGlyphBurst(ctx, metrics, accentColor);
+    }
+
+    if (/Cosmic|Interdimensional/i.test(origin)) {
+      drawKirbyKrackle(ctx, metrics, accentColor);
+    } else if (/Technological/i.test(origin)) {
+      drawTechGlyphs(ctx, metrics, secondaryColor);
+    }
   }
 
-  if (power) {
-    drawPowerGlyphBurst(ctx, metrics, accentColor);
+  if (artLoaded) {
+    drawHeroArtAura(ctx, hero, artFrame);
   }
 
-  if (/Cosmic|Interdimensional/i.test(origin)) {
-    drawKirbyKrackle(ctx, metrics, accentColor);
-  } else if (/Technological/i.test(origin)) {
-    drawTechGlyphs(ctx, metrics, secondaryColor);
-  }
+  drawPresetForeground(ctx, metrics, hero, width, canvasHeight);
+  drawPanelTexture(ctx, width, canvasHeight, hero, metrics);
+  drawSpeechBubble(ctx, metrics, hero, width, canvasHeight, artFrame);
+  drawActionBurst(ctx, metrics, hero, artFrame);
+  drawPanelVignette(ctx, width, canvasHeight);
+  drawPanelFrame(ctx, width, canvasHeight, hero);
+}
 
-  drawSpeechBubble(ctx, metrics, hero, width, canvasHeight);
-  drawActionBurst(ctx, metrics, hero);
-  drawPanelFrame(ctx, width, canvasHeight, name, alignment, accentColor);
+function computeHeroArtFrame(config, canvasWidth, canvasHeight, image) {
+  if (!config) {
+    return null;
+  }
+  const frame = config.frame || {};
+  const heightRatio = clamp(frame.heightRatio ?? 0.78, 0.35, 1);
+  const baselineRatio = clamp(frame.baseline ?? 0.9, 0.55, 1.05);
+  const centerRatio = clamp(frame.centerX ?? 0.5, 0.1, 0.9);
+  const fallbackWidthRatio = clamp(frame.widthRatio ?? 0.42, 0.2, 0.9);
+  const targetHeight = canvasHeight * heightRatio;
+  let targetWidth = canvasWidth * fallbackWidthRatio;
+  if (image?.naturalWidth && image?.naturalHeight) {
+    const aspect = image.naturalWidth / image.naturalHeight;
+    if (Number.isFinite(aspect) && aspect > 0) {
+      targetWidth = targetHeight * aspect;
+    }
+  }
+  const centerX = canvasWidth * centerRatio;
+  const baselineY = canvasHeight * baselineRatio;
+  const x = centerX - targetWidth / 2;
+  const y = baselineY - targetHeight;
+  return { x, y, width: targetWidth, height: targetHeight, baselineY, centerX };
+}
+
+function drawIllustratedHero(ctx, hero, image, frame) {
+  if (!image || !frame) {
+    return;
+  }
+  const accent = hero.accentColor || hero.primaryColor || "#ffffff";
+  const ink = setAlpha("#050209", 0.85);
+
+  ctx.save();
+  ctx.shadowColor = setAlpha(hero.secondaryColor || hero.primaryColor || "#000000", 0.45);
+  ctx.shadowBlur = 24;
+  ctx.shadowOffsetX = 0;
+  ctx.shadowOffsetY = 10;
+  ctx.drawImage(image, frame.x, frame.y, frame.width, frame.height);
+  ctx.restore();
+
+  ctx.save();
+  ctx.globalCompositeOperation = "multiply";
+  const depthGradient = ctx.createLinearGradient(frame.x, frame.y, frame.x, frame.y + frame.height);
+  depthGradient.addColorStop(0, setAlpha(adjustColor(accent, 30), 0.1));
+  depthGradient.addColorStop(0.55, setAlpha("#000000", 0));
+  depthGradient.addColorStop(1, setAlpha("#000000", 0.2));
+  ctx.fillStyle = depthGradient;
+  ctx.fillRect(frame.x, frame.y, frame.width, frame.height);
+  ctx.restore();
+
+  ctx.save();
+  ctx.lineWidth = Math.max(frame.width * 0.005, 2.4);
+  ctx.strokeStyle = ink;
+  ctx.strokeRect(frame.x + 1.5, frame.y + 1.5, frame.width - 3, frame.height - 3);
+  ctx.restore();
+}
+
+function drawIllustratedPlaceholder(ctx, hero, frameOrMetrics) {
+  if (!frameOrMetrics) {
+    return;
+  }
+  const fallbackHeight = frameOrMetrics.height ?? frameOrMetrics.figureHeight ?? 320;
+  const fallbackWidth = frameOrMetrics.width ?? fallbackHeight * 0.58;
+  const estimatedCenter =
+    frameOrMetrics.centerX ??
+    (typeof frameOrMetrics.x === "number"
+      ? frameOrMetrics.x + (frameOrMetrics.width ?? fallbackWidth) / 2
+      : null);
+  const centerX = Number.isFinite(estimatedCenter) ? estimatedCenter : canvas.width / 2;
+  const estimatedBaseline =
+    frameOrMetrics.baselineY ??
+    frameOrMetrics.baseY ??
+    (typeof frameOrMetrics.y === "number"
+      ? frameOrMetrics.y + (frameOrMetrics.height ?? fallbackHeight)
+      : null);
+  let baselineY = Number.isFinite(estimatedBaseline) ? estimatedBaseline : null;
+  if (!Number.isFinite(baselineY)) {
+    baselineY = typeof canvas.height === "number" && canvas.height > 0 ? canvas.height * 0.88 : fallbackHeight;
+  }
+  const width = frameOrMetrics.width ?? fallbackWidth;
+  const height = frameOrMetrics.height ?? fallbackHeight;
+  const x = frameOrMetrics.x ?? centerX - width / 2;
+  const y = frameOrMetrics.y ?? baselineY - height;
+  const primary = hero.primaryColor || "#6c7cfc";
+  const secondary = hero.secondaryColor || adjustColor(primary, -20);
+
+  ctx.save();
+  ctx.beginPath();
+  ctx.moveTo(x + width * 0.5, y);
+  ctx.quadraticCurveTo(x + width, y + height * 0.1, x + width, y + height * 0.42);
+  ctx.quadraticCurveTo(x + width, y + height * 0.92, x + width * 0.5, y + height);
+  ctx.quadraticCurveTo(x, y + height * 0.92, x, y + height * 0.42);
+  ctx.quadraticCurveTo(x, y + height * 0.1, x + width * 0.5, y);
+  ctx.closePath();
+  const gradient = ctx.createLinearGradient(x, y, x, y + height);
+  gradient.addColorStop(0, setAlpha(primary, 0.34));
+  gradient.addColorStop(0.5, setAlpha(secondary, 0.28));
+  gradient.addColorStop(1, setAlpha("#05020d", 0.45));
+  ctx.fillStyle = gradient;
+  ctx.fill();
+  ctx.lineWidth = Math.max(width * 0.01, 2);
+  ctx.setLineDash([10, 8]);
+  ctx.strokeStyle = setAlpha("#ffffff", 0.4);
+  ctx.stroke();
+
+  ctx.setLineDash([]);
+  ctx.globalAlpha = 0.35;
+  ctx.strokeStyle = setAlpha(hero.accentColor || "#ffffff", 0.45);
+  ctx.lineWidth = 2;
+  ctx.beginPath();
+  ctx.moveTo(x + width * 0.18, y + height * 0.22);
+  ctx.lineTo(x + width * 0.82, y + height * 0.78);
+  ctx.moveTo(x + width * 0.82, y + height * 0.22);
+  ctx.lineTo(x + width * 0.18, y + height * 0.78);
+  ctx.stroke();
+
+  ctx.restore();
+
+  ctx.save();
+  ctx.fillStyle = setAlpha("#ffffff", 0.86);
+  ctx.font = "600 18px 'Inter', sans-serif";
+  ctx.textAlign = "center";
+  ctx.fillText("INKING HERO...", centerX, y + height * 0.52);
+  ctx.restore();
+}
+
+function drawHeroArtAura(ctx, hero, frame) {
+  if (!frame) {
+    return;
+  }
+  const accent = hero.accentColor || hero.primaryColor || "#ffffff";
+  const auraCenterX = frame.centerX;
+  const auraCenterY = frame.y + frame.height * 0.45;
+  const auraRadius = Math.max(frame.width, frame.height) * 0.68;
+
+  ctx.save();
+  ctx.globalCompositeOperation = "screen";
+  const gradient = ctx.createRadialGradient(
+    auraCenterX,
+    auraCenterY,
+    auraRadius * 0.15,
+    auraCenterX,
+    auraCenterY,
+    auraRadius
+  );
+  gradient.addColorStop(0, setAlpha(accent, 0.6));
+  gradient.addColorStop(0.35, setAlpha(hero.primaryColor || accent, 0.18));
+  gradient.addColorStop(1, setAlpha("#000000", 0));
+  ctx.fillStyle = gradient;
+  ctx.beginPath();
+  ctx.ellipse(auraCenterX, auraCenterY, auraRadius * 0.9, auraRadius * 0.7, 0, 0, Math.PI * 2);
+  ctx.fill();
+  ctx.restore();
 }
 
 function mapHeight(heightLabel, canvasHeight) {
@@ -215,6 +664,525 @@ function drawBackdrop(ctx, width, height, hero) {
   ctx.restore();
 }
 
+function drawBackdropLinework(ctx, width, height, hero, metrics) {
+  drawPerspectiveCityGrid(ctx, width, height, hero, metrics);
+  drawPerspectiveGround(ctx, width, height, hero, metrics);
+  drawPanelSpeedlines(ctx, width, height, hero, metrics);
+}
+
+function drawPerspectiveCityGrid(ctx, width, height, hero, metrics) {
+  ctx.save();
+  const horizon = height * 0.68;
+  const buildingCount = 7;
+  const bandWidth = width / (buildingCount - 1);
+  const baseCandidate = hero.secondaryColor || hero.primaryColor || "#555555";
+  const baseColor =
+    typeof baseCandidate === "string" && baseCandidate.trim().startsWith("#")
+      ? baseCandidate
+      : "#555555";
+
+  for (let i = -1; i < buildingCount; i++) {
+    const baseX = i * bandWidth * 0.85;
+    const buildingHeight = metrics.figureHeight * (0.45 + ((i % 3) * 0.08 + 0.12));
+    const skew = bandWidth * 0.18 * (i % 2 === 0 ? -1 : 1);
+    const topWidth = bandWidth * (0.45 + ((i % 2) * 0.08));
+    const path = new Path2D();
+    path.moveTo(baseX, height);
+    path.lineTo(baseX + bandWidth, height);
+    path.lineTo(baseX + topWidth + skew, horizon - buildingHeight);
+    path.lineTo(baseX + skew * 0.2, horizon - buildingHeight * 0.95);
+    path.closePath();
+
+    ctx.globalAlpha = 0.45;
+    ctx.fillStyle = setAlpha(darkenColor(baseColor, 42 - (i % 4) * 8), 0.55);
+    ctx.fill(path);
+
+    ctx.globalAlpha = 0.9;
+    ctx.lineWidth = metrics.inkWeight * 0.6;
+    ctx.strokeStyle = setAlpha("#050209", 0.65);
+    ctx.stroke(path);
+
+    ctx.save();
+    ctx.clip(path);
+    ctx.lineWidth = metrics.inkWeight * 0.22;
+    ctx.strokeStyle = setAlpha("#ffffff", 0.16);
+    const rows = 6;
+    for (let r = 1; r < rows; r++) {
+      const y = height - (buildingHeight * r) / rows;
+      ctx.beginPath();
+      ctx.moveTo(baseX - bandWidth * 0.15, y);
+      ctx.lineTo(baseX + bandWidth * 1.1, y - skew * 0.18);
+      ctx.stroke();
+    }
+    const columns = 3;
+    for (let c = 1; c < columns; c++) {
+      const x = baseX + (bandWidth * c) / columns;
+      ctx.beginPath();
+      ctx.moveTo(x, height);
+      ctx.lineTo(x + skew * 0.6, horizon - buildingHeight * 0.92);
+      ctx.strokeStyle = setAlpha("#050209", 0.18);
+      ctx.stroke();
+    }
+    ctx.restore();
+  }
+  ctx.restore();
+}
+
+function drawPerspectiveGround(ctx, width, height, hero, metrics) {
+  ctx.save();
+  const vanishX = width / 2 + metrics.shoulderWidth * 0.2;
+  const vanishY = metrics.baseY - metrics.figureHeight * 0.35;
+  ctx.lineWidth = metrics.inkWeight * 0.3;
+  ctx.strokeStyle = setAlpha("#050209", 0.28);
+  for (let i = -8; i <= 8; i++) {
+    ctx.beginPath();
+    ctx.moveTo(i * width * 0.12, height);
+    ctx.lineTo(vanishX + i * 4, vanishY);
+    ctx.stroke();
+  }
+
+  ctx.strokeStyle = setAlpha("#ffffff", 0.12);
+  const lanes = 4;
+  for (let l = 1; l <= lanes; l++) {
+    const t = l / (lanes + 1);
+    const y = metrics.baseY + metrics.figureHeight * 0.1 * l;
+    ctx.beginPath();
+    ctx.moveTo(-width * 0.2, y);
+    ctx.quadraticCurveTo(vanishX, vanishY + metrics.figureHeight * 0.15 * t, width * 1.2, y);
+    ctx.stroke();
+  }
+
+  ctx.restore();
+}
+
+function drawPanelSpeedlines(ctx, width, height, hero, metrics) {
+  ctx.save();
+  ctx.globalAlpha = 0.35;
+  const accentCandidate = hero.accentColor || hero.primaryColor || "#ffffff";
+  const accent =
+    typeof accentCandidate === "string" && accentCandidate.trim().startsWith("#")
+      ? accentCandidate
+      : "#ffffff";
+  ctx.strokeStyle = setAlpha(adjustColor(accent, -20), 0.45);
+  ctx.lineWidth = metrics.inkWeight * 0.45;
+  const vanishX = metrics.centerX;
+  const vanishY = metrics.baseY - metrics.figureHeight * 0.55;
+  for (let i = 0; i < 7; i++) {
+    const offset = i / 6;
+    ctx.beginPath();
+    ctx.moveTo(-width * 0.05, height * (0.12 + offset * 0.45));
+    ctx.lineTo(vanishX - metrics.shoulderWidth * 0.6 + offset * metrics.shoulderWidth * 0.9, vanishY);
+    ctx.stroke();
+
+    ctx.beginPath();
+    ctx.moveTo(width * 1.05, height * (0.12 + offset * 0.45));
+    ctx.lineTo(vanishX + metrics.shoulderWidth * 0.6 - offset * metrics.shoulderWidth * 0.9, vanishY);
+    ctx.stroke();
+  }
+  ctx.restore();
+}
+
+function drawPresetBackdrop(ctx, width, height, hero, metrics) {
+  switch (hero.presetKey) {
+    case "cosmic-guardian":
+      drawCosmicBackdrop(ctx, width, height, hero, metrics);
+      break;
+    case "neon-rogue":
+      drawNeonBackdrop(ctx, width, height, hero, metrics);
+      break;
+    case "mythic-sorcerer":
+      drawMythicBackdrop(ctx, width, height, hero, metrics);
+      break;
+    case "shadow-operative":
+      drawShadowBackdrop(ctx, width, height, hero, metrics);
+      break;
+    case "atomic-sentinel":
+      drawAtomicBackdrop(ctx, width, height, hero, metrics);
+      break;
+    default:
+      break;
+  }
+}
+
+function drawPresetForeground(ctx, metrics, hero, width, height) {
+  switch (hero.presetKey) {
+    case "cosmic-guardian":
+      drawCosmicForeground(ctx, metrics, hero);
+      break;
+    case "neon-rogue":
+      drawNeonForeground(ctx, metrics, hero, width, height);
+      break;
+    case "mythic-sorcerer":
+      drawMythicForeground(ctx, metrics, hero);
+      break;
+    case "shadow-operative":
+      drawShadowForeground(ctx, metrics, hero, width, height);
+      break;
+    case "atomic-sentinel":
+      drawAtomicForeground(ctx, metrics, hero);
+      break;
+    default:
+      break;
+  }
+}
+
+function drawCosmicBackdrop(ctx, width, height, hero, metrics) {
+  ctx.save();
+  const auraY = metrics.baseY - metrics.figureHeight * 0.62;
+  const auraRadius = metrics.figureHeight * 0.86;
+  const gradient = ctx.createRadialGradient(
+    metrics.centerX,
+    auraY,
+    auraRadius * 0.15,
+    metrics.centerX,
+    auraY,
+    auraRadius
+  );
+  gradient.addColorStop(0, setAlpha(hero.accentColor, 0.55));
+  gradient.addColorStop(0.55, setAlpha(hero.primaryColor, 0.18));
+  gradient.addColorStop(1, setAlpha("#02020f", 0));
+  ctx.fillStyle = gradient;
+  ctx.beginPath();
+  ctx.ellipse(metrics.centerX, auraY, auraRadius * 0.92, auraRadius * 0.78, 0, 0, Math.PI * 2);
+  ctx.fill();
+  ctx.restore();
+
+  ctx.save();
+  ctx.translate(metrics.centerX, auraY);
+  ctx.globalAlpha = 0.55;
+  for (let i = 0; i < 4; i++) {
+    ctx.beginPath();
+    ctx.rotate((Math.PI / 8) * i);
+    ctx.strokeStyle = setAlpha(hero.secondaryColor, 0.5 - i * 0.08);
+    ctx.lineWidth = metrics.inkWeight * (1.2 - i * 0.15);
+    ctx.ellipse(0, 0, auraRadius * (0.55 + i * 0.12), auraRadius * (0.32 + i * 0.08), 0, 0, Math.PI * 2);
+    ctx.stroke();
+  }
+  ctx.restore();
+
+  ctx.save();
+  ctx.globalAlpha = 0.3;
+  for (let i = 0; i < 40; i++) {
+    const angle = (Math.PI * 2 * i) / 40;
+    const orbitRadius = auraRadius * (0.35 + (i % 5) * 0.05);
+    const x = metrics.centerX + Math.cos(angle) * orbitRadius;
+    const y = auraY + Math.sin(angle) * orbitRadius * 0.72;
+    const size = (i % 7) * 0.8 + 1.5;
+    ctx.beginPath();
+    ctx.fillStyle = setAlpha(hero.accentColor, 0.5);
+    ctx.arc(x, y, size, 0, Math.PI * 2);
+    ctx.fill();
+  }
+  ctx.restore();
+}
+
+function drawCosmicForeground(ctx, metrics, hero) {
+  ctx.save();
+  ctx.translate(metrics.centerX, metrics.baseY - metrics.figureHeight * 0.54);
+  ctx.globalAlpha = 0.7;
+  for (let i = 0; i < 5; i++) {
+    const rotation = (Math.PI * i) / 5;
+    ctx.save();
+    ctx.rotate(rotation);
+    ctx.beginPath();
+    ctx.strokeStyle = setAlpha(hero.accentColor, 0.55 - i * 0.08);
+    ctx.lineWidth = metrics.inkWeight * 0.7;
+    ctx.moveTo(metrics.figureHeight * 0.05, 0);
+    ctx.quadraticCurveTo(
+      metrics.figureHeight * 0.28,
+      -metrics.figureHeight * 0.1,
+      metrics.figureHeight * 0.36,
+      0
+    );
+    ctx.stroke();
+    ctx.restore();
+  }
+
+  ctx.globalAlpha = 0.65;
+  for (let i = 0; i < 20; i++) {
+    const angle = (Math.PI * 2 * i) / 20;
+    const radius = metrics.figureHeight * (0.2 + (i % 4) * 0.05);
+    const x = Math.cos(angle) * radius;
+    const y = Math.sin(angle) * radius * 0.6;
+    ctx.beginPath();
+    ctx.fillStyle = setAlpha(hero.secondaryColor, 0.4);
+    ctx.arc(x, y, metrics.figureHeight * 0.015 * ((i % 3) + 1), 0, Math.PI * 2);
+    ctx.fill();
+  }
+  ctx.restore();
+}
+
+function drawNeonBackdrop(ctx, width, height, hero, metrics) {
+  const horizon = height * 0.74;
+  ctx.save();
+  ctx.globalAlpha = 0.85;
+  for (let i = -1; i < 9; i++) {
+    const buildingWidth = width / 8;
+    const x = i * buildingWidth + Math.random() * 18 - 9;
+    const buildingHeight = metrics.figureHeight * (0.6 + Math.random() * 0.6);
+    ctx.fillStyle = setAlpha(hero.secondaryColor, 0.9);
+    ctx.fillRect(x, horizon - buildingHeight, buildingWidth * 0.9, buildingHeight);
+
+    ctx.fillStyle = setAlpha(hero.accentColor, 0.45);
+    const windowCount = 6;
+    for (let w = 0; w < windowCount; w++) {
+      const wx = x + buildingWidth * 0.15 + (w % 2) * buildingWidth * 0.35;
+      const wy = horizon - buildingHeight + (w + 1) * (buildingHeight / (windowCount + 1));
+      ctx.fillRect(wx, wy, buildingWidth * 0.18, buildingHeight * 0.03);
+    }
+  }
+  ctx.restore();
+
+  ctx.save();
+  ctx.beginPath();
+  ctx.rect(0, horizon, width, height - horizon);
+  ctx.clip();
+  ctx.globalAlpha = 0.6;
+  ctx.strokeStyle = setAlpha(hero.primaryColor, 0.45);
+  ctx.lineWidth = 1.5;
+  for (let i = 1; i < 8; i++) {
+    const y = horizon + i * metrics.figureHeight * 0.08;
+    ctx.beginPath();
+    ctx.moveTo(0, y);
+    ctx.lineTo(width, y);
+    ctx.stroke();
+  }
+
+  ctx.strokeStyle = setAlpha(hero.accentColor, 0.35);
+  for (let i = -6; i <= 6; i++) {
+    ctx.beginPath();
+    ctx.moveTo(metrics.centerX + i * metrics.figureHeight * 0.18, horizon);
+    ctx.lineTo(metrics.centerX + i * metrics.figureHeight * 0.05, height);
+    ctx.stroke();
+  }
+  ctx.restore();
+}
+
+function drawNeonForeground(ctx, metrics, hero, width, height) {
+  ctx.save();
+  ctx.globalCompositeOperation = "lighter";
+  ctx.strokeStyle = setAlpha(hero.accentColor, 0.65);
+  ctx.lineWidth = metrics.inkWeight * 0.7;
+  for (let i = 0; i < 6; i++) {
+    ctx.beginPath();
+    const offset = (i - 3) * metrics.figureHeight * 0.08;
+    ctx.moveTo(metrics.centerX + offset, metrics.baseY - metrics.figureHeight * 0.78);
+    ctx.quadraticCurveTo(
+      metrics.centerX + offset * 1.4,
+      metrics.baseY - metrics.figureHeight * 0.4,
+      metrics.centerX + offset * 0.3,
+      metrics.baseY - metrics.figureHeight * 0.05
+    );
+    ctx.stroke();
+  }
+
+  ctx.globalCompositeOperation = "source-over";
+  ctx.fillStyle = setAlpha(hero.secondaryColor, 0.4);
+  for (let i = 0; i < 18; i++) {
+    const x = metrics.centerX + (Math.random() - 0.5) * metrics.shoulderWidth * 2.4;
+    const y = metrics.baseY - Math.random() * metrics.figureHeight * 0.9;
+    const widthPulse = metrics.figureHeight * 0.05 * Math.random();
+    const heightPulse = metrics.figureHeight * 0.12 * Math.random();
+    ctx.fillRect(x, y, widthPulse, heightPulse);
+  }
+  ctx.restore();
+}
+
+function drawMythicBackdrop(ctx, width, height, hero, metrics) {
+  ctx.save();
+  ctx.translate(metrics.centerX, metrics.baseY - metrics.figureHeight * 0.58);
+  const radius = metrics.figureHeight * 0.68;
+  const gradient = ctx.createRadialGradient(0, 0, radius * 0.1, 0, 0, radius);
+  gradient.addColorStop(0, setAlpha(hero.accentColor, 0.65));
+  gradient.addColorStop(0.6, setAlpha(hero.secondaryColor, 0.22));
+  gradient.addColorStop(1, setAlpha("#120620", 0));
+  ctx.fillStyle = gradient;
+  ctx.beginPath();
+  ctx.arc(0, 0, radius, 0, Math.PI * 2);
+  ctx.fill();
+
+  ctx.strokeStyle = setAlpha(hero.secondaryColor, 0.75);
+  ctx.lineWidth = metrics.inkWeight * 0.8;
+  for (let i = 0; i < 3; i++) {
+    ctx.beginPath();
+    ctx.arc(0, 0, radius * (0.55 + i * 0.15), 0, Math.PI * 2);
+    ctx.stroke();
+  }
+
+  const glyphs = ["✧", "☉", "✴", "☽", "❂", "✦"];
+  ctx.fillStyle = setAlpha(hero.accentColor, 0.8);
+  ctx.font = `600 ${Math.round(metrics.figureHeight * 0.08)}px 'Bangers', sans-serif`;
+  for (let i = 0; i < glyphs.length; i++) {
+    const angle = (Math.PI * 2 * i) / glyphs.length;
+    const glyphRadius = radius * 0.72;
+    ctx.save();
+    ctx.rotate(angle);
+    ctx.fillText(glyphs[i], glyphRadius - radius * 0.05, 0);
+    ctx.restore();
+  }
+  ctx.restore();
+}
+
+function drawMythicForeground(ctx, metrics, hero) {
+  ctx.save();
+  ctx.translate(metrics.centerX, metrics.baseY - metrics.figureHeight * 0.4);
+  ctx.fillStyle = setAlpha(hero.accentColor, 0.6);
+  for (let i = 0; i < 12; i++) {
+    const angle = (Math.PI * 2 * i) / 12;
+    const distance = metrics.figureHeight * 0.4;
+    const x = Math.cos(angle) * distance * 0.4;
+    const y = Math.sin(angle) * distance * 0.4;
+    ctx.beginPath();
+    ctx.arc(x, y, metrics.figureHeight * 0.025, 0, Math.PI * 2);
+    ctx.fill();
+  }
+
+  ctx.strokeStyle = setAlpha(hero.secondaryColor, 0.7);
+  ctx.lineWidth = metrics.inkWeight * 0.6;
+  for (let i = 0; i < 6; i++) {
+    ctx.beginPath();
+    const outerRadius = metrics.figureHeight * 0.45;
+    const startAngle = (Math.PI * 2 * i) / 6;
+    ctx.arc(0, 0, outerRadius, startAngle, startAngle + Math.PI * 0.2);
+    ctx.stroke();
+  }
+  ctx.restore();
+}
+
+function drawShadowBackdrop(ctx, width, height, hero, metrics) {
+  ctx.save();
+  const spotlight = ctx.createRadialGradient(
+    metrics.centerX,
+    metrics.baseY - metrics.figureHeight * 0.85,
+    metrics.figureHeight * 0.2,
+    metrics.centerX,
+    metrics.baseY,
+    metrics.figureHeight * 1.6
+  );
+  spotlight.addColorStop(0, setAlpha(hero.secondaryColor, 0.45));
+  spotlight.addColorStop(0.4, setAlpha(hero.secondaryColor, 0.18));
+  spotlight.addColorStop(1, setAlpha("#020109", 0));
+  ctx.fillStyle = spotlight;
+  ctx.fillRect(0, 0, width, height);
+
+  ctx.globalAlpha = 0.8;
+  ctx.fillStyle = setAlpha(hero.primaryColor, 0.85);
+  const baseY = metrics.baseY + metrics.figureHeight * 0.15;
+  for (let i = -2; i < 10; i++) {
+    const buildingWidth = width / 9;
+    const buildingHeight = metrics.figureHeight * (0.7 + Math.random() * 0.5);
+    const x = i * buildingWidth + Math.random() * 12;
+    ctx.fillRect(x, baseY - buildingHeight, buildingWidth * 0.9, buildingHeight);
+  }
+  ctx.restore();
+}
+
+function drawShadowForeground(ctx, metrics, hero, width, height) {
+  ctx.save();
+  ctx.strokeStyle = setAlpha(hero.secondaryColor, 0.4);
+  ctx.lineWidth = 2;
+  ctx.beginPath();
+  ctx.ellipse(
+    metrics.centerX,
+    metrics.baseY - metrics.figureHeight * 0.55,
+    metrics.figureHeight * 0.5,
+    metrics.figureHeight * 0.32,
+    0,
+    0,
+    Math.PI * 2
+  );
+  ctx.stroke();
+
+  ctx.globalAlpha = 0.55;
+  ctx.strokeStyle = setAlpha("#a6b7ff", 0.45);
+  ctx.lineWidth = 1.2;
+  const rainLines = 60;
+  for (let i = 0; i < rainLines; i++) {
+    const startX = Math.random() * width;
+    const startY = Math.random() * height * 0.9;
+    ctx.beginPath();
+    ctx.moveTo(startX, startY);
+    ctx.lineTo(startX - 6, startY + 18);
+    ctx.stroke();
+  }
+  ctx.restore();
+}
+
+function drawAtomicBackdrop(ctx, width, height, hero, metrics) {
+  ctx.save();
+  ctx.globalAlpha = 0.6;
+  const stripeHeight = metrics.figureHeight * 0.22;
+  for (let i = -2; i < 8; i++) {
+    ctx.beginPath();
+    const y1 = height * 0.58 + stripeHeight * i;
+    const y2 = y1 - stripeHeight * 0.6;
+    ctx.moveTo(-width * 0.1, y1);
+    ctx.lineTo(width * 1.1, y2);
+    ctx.lineTo(width * 1.1, y2 + stripeHeight);
+    ctx.lineTo(-width * 0.1, y1 + stripeHeight);
+    ctx.closePath();
+    ctx.fillStyle = i % 2 === 0 ? setAlpha(hero.accentColor, 0.32) : setAlpha(hero.secondaryColor, 0.28);
+    ctx.fill();
+  }
+  ctx.restore();
+
+  ctx.save();
+  const coreY = metrics.baseY - metrics.figureHeight * 0.6;
+  const coreRadius = metrics.figureHeight * 0.7;
+  const coreGradient = ctx.createRadialGradient(
+    metrics.centerX,
+    coreY,
+    coreRadius * 0.15,
+    metrics.centerX,
+    coreY,
+    coreRadius
+  );
+  coreGradient.addColorStop(0, setAlpha(hero.accentColor, 0.6));
+  coreGradient.addColorStop(0.5, setAlpha(hero.primaryColor, 0.25));
+  coreGradient.addColorStop(1, setAlpha("#120500", 0));
+  ctx.fillStyle = coreGradient;
+  ctx.beginPath();
+  ctx.ellipse(metrics.centerX, coreY, coreRadius * 0.95, coreRadius * 0.82, 0, 0, Math.PI * 2);
+  ctx.fill();
+  ctx.restore();
+}
+
+function drawAtomicForeground(ctx, metrics, hero) {
+  ctx.save();
+  ctx.translate(metrics.centerX, metrics.baseY - metrics.figureHeight * 0.5);
+  ctx.rotate(-0.2);
+  ctx.strokeStyle = setAlpha(hero.accentColor, 0.7);
+  ctx.lineWidth = metrics.inkWeight * 0.9;
+  for (let i = 0; i < 3; i++) {
+    ctx.beginPath();
+    const radius = metrics.figureHeight * (0.35 + i * 0.08);
+    ctx.ellipse(0, 0, radius * 1.1, radius * 0.45, i * 0.6, 0, Math.PI * 2);
+    ctx.stroke();
+  }
+
+  ctx.globalAlpha = 0.6;
+  for (let i = 0; i < 16; i++) {
+    ctx.beginPath();
+    const angle = (Math.PI * 2 * i) / 16;
+    const radius = metrics.figureHeight * 0.5;
+    ctx.moveTo(Math.cos(angle) * radius * 0.2, Math.sin(angle) * radius * 0.2);
+    ctx.lineTo(Math.cos(angle) * radius, Math.sin(angle) * radius);
+    ctx.strokeStyle = setAlpha(hero.primaryColor, 0.5);
+    ctx.lineWidth = metrics.inkWeight * 0.5;
+    ctx.stroke();
+  }
+
+  ctx.fillStyle = setAlpha(hero.accentColor, 0.6);
+  for (let i = 0; i < 10; i++) {
+    const angle = (Math.PI * 2 * i) / 10;
+    const radius = metrics.figureHeight * (0.25 + (i % 5) * 0.04);
+    ctx.beginPath();
+    ctx.arc(Math.cos(angle) * radius, Math.sin(angle) * radius, metrics.figureHeight * 0.02, 0, Math.PI * 2);
+    ctx.fill();
+  }
+  ctx.restore();
+}
+
 function drawSunburst(ctx, width, height, accent) {
   ctx.save();
   ctx.globalAlpha = 0.4;
@@ -232,19 +1200,15 @@ function drawSunburst(ctx, width, height, accent) {
   ctx.restore();
 }
 
-function drawGroundShadow(ctx, metrics) {
+function drawGroundShadow(ctx, metrics, overrides = {}) {
+  const centerX = overrides.centerX ?? metrics.centerX;
+  const baseY = overrides.baseY ?? metrics.baseY + metrics.figureHeight * 0.02;
+  const width = overrides.width ?? metrics.figureHeight * 0.32;
+  const height = overrides.height ?? metrics.figureHeight * 0.12;
   ctx.save();
   ctx.fillStyle = setAlpha("#000000", 0.42);
   ctx.beginPath();
-  ctx.ellipse(
-    metrics.centerX,
-    metrics.baseY + metrics.figureHeight * 0.02,
-    metrics.figureHeight * 0.32,
-    metrics.figureHeight * 0.12,
-    0,
-    0,
-    Math.PI * 2
-  );
+  ctx.ellipse(centerX, baseY, width, height, 0, 0, Math.PI * 2);
   ctx.fill();
   ctx.restore();
 }
@@ -258,10 +1222,9 @@ function drawDrapedCape(ctx, metrics, color, jagged) {
   gradient.addColorStop(0, adjustColor(color, 45));
   gradient.addColorStop(0.5, color);
   gradient.addColorStop(1, adjustColor(color, -55));
-  ctx.fillStyle = gradient;
-  ctx.beginPath();
-  ctx.moveTo(metrics.centerX - capeWidth * 0.4, capeTop);
-  ctx.quadraticCurveTo(
+  const capePath = new Path2D();
+  capePath.moveTo(metrics.centerX - capeWidth * 0.4, capeTop);
+  capePath.quadraticCurveTo(
     metrics.centerX - capeWidth * 0.7,
     metrics.baseY - metrics.figureHeight * 0.1,
     metrics.centerX - capeWidth * 0.45,
@@ -273,20 +1236,41 @@ function drawDrapedCape(ctx, metrics, color, jagged) {
       const t = i / segments;
       const x = metrics.centerX - capeWidth * 0.45 + capeWidth * 0.9 * t;
       const peak = capeBottom + (i % 2 === 0 ? 14 : -12);
-      ctx.lineTo(x, peak);
+      capePath.lineTo(x, peak);
     }
+  } else {
+    capePath.lineTo(metrics.centerX + capeWidth * 0.45, capeBottom);
   }
-  ctx.quadraticCurveTo(
+  capePath.quadraticCurveTo(
     metrics.centerX + capeWidth * 0.7,
     metrics.baseY - metrics.figureHeight * 0.08,
     metrics.centerX + capeWidth * 0.4,
     capeTop
   );
-  ctx.closePath();
-  ctx.fill();
+  capePath.closePath();
+
+  ctx.fillStyle = gradient;
+  ctx.fill(capePath);
   ctx.lineWidth = metrics.inkWeight * 0.9;
   ctx.strokeStyle = setAlpha("#050209", 0.9);
-  ctx.stroke();
+  ctx.stroke(capePath);
+
+  ctx.save();
+  ctx.clip(capePath);
+  drawCrosshatchTexture(
+    ctx,
+    metrics.centerX - capeWidth * 0.55,
+    capeTop,
+    capeWidth * 1.1,
+    capeBottom - capeTop,
+    {
+      spacing: metrics.figureHeight * 0.06,
+      weight: metrics.inkWeight * 0.18,
+      alpha: 0.14,
+    }
+  );
+  ctx.restore();
+
   ctx.restore();
 }
 
@@ -363,6 +1347,18 @@ function drawLeg(ctx, metrics, hero, side) {
   ctx.strokeStyle = setAlpha("#050209", 0.55);
   ctx.lineWidth = metrics.inkWeight * 0.45;
   ctx.stroke();
+  drawCrosshatchTexture(
+    ctx,
+    hipX - metrics.limbWidth * 0.9,
+    metrics.hipY,
+    metrics.limbWidth * 1.8,
+    metrics.figureHeight * 0.6,
+    {
+      spacing: metrics.figureHeight * 0.045,
+      weight: metrics.inkWeight * 0.16,
+      alpha: 0.18,
+    }
+  );
   ctx.restore();
 
   ctx.save();
@@ -547,6 +1543,18 @@ function drawTorso(ctx, metrics, hero) {
   ctx.strokeStyle = setAlpha("#050209", 0.5);
   ctx.lineWidth = metrics.inkWeight * 0.38;
   ctx.stroke();
+  drawCrosshatchTexture(
+    ctx,
+    metrics.centerX - metrics.shoulderWidth * 0.8,
+    metrics.shoulderY,
+    metrics.shoulderWidth * 1.6,
+    metrics.figureHeight * 0.72,
+    {
+      spacing: metrics.figureHeight * 0.05,
+      weight: metrics.inkWeight * 0.16,
+      alpha: 0.16,
+    }
+  );
   ctx.restore();
 
   ctx.save();
@@ -701,6 +1709,18 @@ function drawArm(ctx, metrics, hero, side) {
   ctx.strokeStyle = setAlpha("#050209", 0.55);
   ctx.lineWidth = metrics.inkWeight * 0.45;
   ctx.stroke();
+  drawCrosshatchTexture(
+    ctx,
+    shoulderX - metrics.limbWidth * 0.9,
+    metrics.shoulderY,
+    metrics.limbWidth * 1.8,
+    metrics.figureHeight * 0.45,
+    {
+      spacing: metrics.figureHeight * 0.04,
+      weight: metrics.inkWeight * 0.15,
+      alpha: 0.18,
+    }
+  );
   ctx.restore();
 
   ctx.save();
@@ -1004,6 +2024,62 @@ function inkMuscleContours(ctx, metrics, hero) {
   ctx.restore();
 }
 
+function drawFigureSketchLines(ctx, metrics) {
+  ctx.save();
+  ctx.strokeStyle = setAlpha("#050209", 0.3);
+  ctx.lineWidth = metrics.inkWeight * 0.2;
+  const leftEdge = metrics.centerX - metrics.shoulderWidth * 0.58;
+  const rightEdge = metrics.centerX + metrics.shoulderWidth * 0.58;
+  const tickCount = 10;
+  for (let i = 0; i < tickCount; i++) {
+    const y = metrics.topY + metrics.headHeight * 0.3 + i * metrics.figureHeight * 0.055;
+    ctx.beginPath();
+    ctx.moveTo(leftEdge - metrics.figureHeight * 0.02, y);
+    ctx.lineTo(leftEdge, y + metrics.figureHeight * 0.012);
+    ctx.stroke();
+
+    ctx.beginPath();
+    ctx.moveTo(rightEdge + metrics.figureHeight * 0.02, y);
+    ctx.lineTo(rightEdge, y + metrics.figureHeight * 0.012);
+    ctx.stroke();
+  }
+  ctx.restore();
+
+  ctx.save();
+  ctx.strokeStyle = setAlpha("#ffffff", 0.18);
+  ctx.lineWidth = metrics.inkWeight * 0.16;
+  ctx.setLineDash([metrics.figureHeight * 0.015, metrics.figureHeight * 0.02]);
+  ctx.beginPath();
+  ctx.ellipse(
+    metrics.centerX,
+    metrics.baseY - metrics.figureHeight * 0.2,
+    metrics.shoulderWidth * 0.9,
+    metrics.figureHeight * 0.32,
+    0,
+    0,
+    Math.PI * 2
+  );
+  ctx.stroke();
+  ctx.restore();
+
+  ctx.save();
+  ctx.strokeStyle = setAlpha("#050209", 0.34);
+  ctx.lineWidth = metrics.inkWeight * 0.18;
+  for (let i = -2; i <= 2; i++) {
+    ctx.beginPath();
+    const arcY = metrics.baseY + metrics.figureHeight * 0.05 + i * metrics.figureHeight * 0.02;
+    ctx.moveTo(metrics.centerX - metrics.shoulderWidth * 0.52, arcY);
+    ctx.quadraticCurveTo(
+      metrics.centerX,
+      arcY + metrics.figureHeight * 0.05,
+      metrics.centerX + metrics.shoulderWidth * 0.52,
+      arcY
+    );
+    ctx.stroke();
+  }
+  ctx.restore();
+}
+
 function drawHeadAndFace(ctx, metrics, hero) {
   const cheekWidth = metrics.shoulderWidth * 0.26;
   const jawWidth = metrics.shoulderWidth * 0.18;
@@ -1165,6 +2241,32 @@ function drawHeadAndFace(ctx, metrics, hero) {
   );
   ctx.restore();
 
+  ctx.restore();
+
+  ctx.save();
+  ctx.beginPath();
+  ctx.ellipse(
+    metrics.centerX,
+    metrics.eyeY + metrics.headHeight * 0.38,
+    cheekWidth * 0.9,
+    metrics.headHeight * 0.35,
+    0,
+    0,
+    Math.PI * 2
+  );
+  ctx.clip();
+  drawCrosshatchTexture(
+    ctx,
+    metrics.centerX - cheekWidth,
+    metrics.eyeY,
+    cheekWidth * 2,
+    metrics.headHeight * 0.9,
+    {
+      spacing: metrics.figureHeight * 0.03,
+      weight: metrics.inkWeight * 0.14,
+      alpha: 0.2,
+    }
+  );
   ctx.restore();
 
   ctx.save();
@@ -1442,31 +2544,89 @@ function drawTechBackdrop(ctx, width, height, color) {
   ctx.restore();
 }
 
-function drawPanelFrame(ctx, width, height, name, alignment, accent) {
+function drawPanelFrame(ctx, width, height, hero) {
   ctx.save();
-  ctx.lineWidth = 8;
+  const accent = hero.accentColor || "#fdea55";
+  const secondary = hero.secondaryColor || "#ffffff";
+
+  ctx.lineWidth = 14;
+  ctx.strokeStyle = setAlpha(adjustColor(accent, -10), 0.95);
+  ctx.strokeRect(4.5, 4.5, width - 9, height - 9);
+
+  ctx.lineWidth = 6;
   ctx.strokeStyle = "#050209";
-  ctx.strokeRect(12, 12, width - 24, height - 24);
+  ctx.strokeRect(10, 10, width - 20, height - 20);
 
-  ctx.lineWidth = 2;
-  ctx.strokeStyle = "#f7f2c7";
-  ctx.strokeRect(6, 6, width - 12, height - 12);
+  ctx.lineWidth = 2.5;
+  ctx.strokeStyle = setAlpha("#fff7d0", 0.85);
+  ctx.strokeRect(18, 18, width - 36, height - 36);
 
-  const captionHeight = 48;
-  ctx.fillStyle = setAlpha("#fff9d0", 0.92);
-  ctx.fillRect(24, height - captionHeight - 16, width - 48, captionHeight);
+  const tickColor = setAlpha(adjustColor(accent, 25), 0.9);
+  const tickLength = 32;
+  ctx.fillStyle = tickColor;
+  ctx.fillRect(24, 20, tickLength, 4);
+  ctx.fillRect(width - 24 - tickLength, height - 24, tickLength, 4);
+  ctx.fillRect(24, height - 24, 4, tickLength * 0.6);
+  ctx.fillRect(width - 28, 20, 4, tickLength * 0.6);
+
+  const strapHeight = 48;
+  const strapY = 28;
+  ctx.fillStyle = setAlpha(adjustColor(secondary, 35), 0.9);
+  ctx.fillRect(34, strapY, width - 68, strapHeight);
+  ctx.save();
+  ctx.beginPath();
+  ctx.rect(34, strapY, width - 68, strapHeight);
+  ctx.clip();
+  ctx.globalAlpha = 0.25;
+  ctx.fillStyle = createHalftonePattern(
+    ctx,
+    setAlpha(adjustColor(accent, 20), 0.8),
+    setAlpha("#ffffff", 0),
+    2.2,
+    8
+  );
+  ctx.fillRect(34, strapY, width - 68, strapHeight);
+  ctx.restore();
   ctx.lineWidth = 3;
   ctx.strokeStyle = "#050209";
-  ctx.strokeRect(24, height - captionHeight - 16, width - 48, captionHeight);
+  ctx.strokeRect(34, strapY, width - 68, strapHeight);
 
   ctx.fillStyle = "#050209";
-  ctx.font = "bold 20px 'Bangers', 'Comic Neue', sans-serif";
   ctx.textBaseline = "middle";
-  ctx.fillText(name || "Unnamed Legend", 36, height - captionHeight - 16 + captionHeight / 2);
+  ctx.textAlign = "left";
+  ctx.font = "bold 20px 'Bangers', 'Comic Neue', sans-serif";
+  const strapLabel = hero.presetKey !== "custom" ? hero.presetLabel : "Custom Mix";
+  ctx.fillText(strapLabel.toUpperCase(), 48, strapY + strapHeight / 2);
+  ctx.textAlign = "right";
+  ctx.font = "600 14px 'Inter', sans-serif";
+  ctx.fillStyle = adjustColor(accent, -5);
+  ctx.fillText(hero.alignment.toUpperCase(), width - 48, strapY + strapHeight / 2);
 
-  ctx.font = "bold 16px 'Comic Neue', sans-serif";
-  ctx.fillStyle = adjustColor(accent, 40);
-  ctx.fillText(alignment, width - 150, height - captionHeight - 16 + captionHeight / 2);
+  const captionHeight = 72;
+  const captionY = height - captionHeight - 32;
+  ctx.fillStyle = setAlpha("#fff9d0", 0.94);
+  ctx.fillRect(42, captionY, width - 84, captionHeight);
+  ctx.lineWidth = 3;
+  ctx.strokeStyle = "#050209";
+  ctx.strokeRect(42, captionY, width - 84, captionHeight);
+
+  ctx.textAlign = "left";
+  ctx.fillStyle = "#050209";
+  ctx.font = `bold ${Math.round(Math.min(28, width * 0.08))}px 'Bangers', 'Comic Neue', sans-serif`;
+  ctx.fillText((hero.name || "Unnamed Legend").toUpperCase(), 58, captionY + captionHeight * 0.38);
+
+  ctx.font = "600 15px 'Inter', sans-serif";
+  ctx.fillStyle = adjustColor(accent, -15);
+  const captionLine =
+    hero.presetKey !== "custom"
+      ? hero.presetTagline || hero.presetLabel
+      : `${hero.alignment} • ${hero.specialty}`;
+  ctx.fillText(captionLine.toUpperCase(), 58, captionY + captionHeight * 0.72);
+
+  ctx.textAlign = "right";
+  ctx.fillStyle = adjustColor(secondary, 15);
+  ctx.font = "bold 16px 'Bangers', sans-serif";
+  ctx.fillText(`SPECIAL ${hero.specialty.toUpperCase()}`, width - 58, captionY + captionHeight * 0.72);
   ctx.restore();
 }
 
@@ -1518,7 +2678,107 @@ function drawPowerGlyphBurst(ctx, metrics, color) {
   ctx.restore();
 }
 
-function drawSpeechBubble(ctx, metrics, hero, width, height) {
+function drawPanelTexture(ctx, width, height, hero, metrics) {
+  ctx.save();
+  ctx.globalAlpha = 0.08;
+  ctx.fillStyle = createHalftonePattern(
+    ctx,
+    setAlpha("#050209", 0.22),
+    setAlpha("#000000", 0),
+    2,
+    6
+  );
+  ctx.fillRect(16, 16, width - 32, height - 32);
+  ctx.restore();
+
+  ctx.save();
+  ctx.globalAlpha = 0.18;
+  ctx.strokeStyle = setAlpha("#050209", 0.24);
+  ctx.lineWidth = metrics.inkWeight * 0.18;
+  const strokes = 70;
+  for (let i = 0; i < strokes; i++) {
+    const startX = Math.random() * width;
+    const startY = Math.random() * height;
+    const angle = -0.9 + Math.random() * 1.8;
+    const length = metrics.figureHeight * (0.08 + Math.random() * 0.12);
+    ctx.beginPath();
+    ctx.moveTo(startX, startY);
+    ctx.lineTo(startX + Math.cos(angle) * length, startY + Math.sin(angle) * length);
+    ctx.stroke();
+  }
+  ctx.restore();
+
+  ctx.save();
+  ctx.globalAlpha = 0.12;
+  ctx.strokeStyle = setAlpha("#ffffff", 0.14);
+  ctx.lineWidth = metrics.inkWeight * 0.2;
+  for (let i = 1; i <= 3; i++) {
+    const radius = Math.min(width, height) * (0.28 + i * 0.1);
+    ctx.beginPath();
+    ctx.ellipse(
+      metrics.centerX,
+      metrics.baseY - metrics.figureHeight * 0.42,
+      radius,
+      radius * 0.55,
+      -0.08,
+      0,
+      Math.PI * 2
+    );
+    ctx.stroke();
+  }
+  ctx.restore();
+
+  ctx.save();
+  ctx.globalAlpha = 0.16;
+  ctx.strokeStyle = setAlpha("#050209", 0.26);
+  ctx.lineWidth = metrics.inkWeight * 0.22;
+  for (let i = 0; i < 4; i++) {
+    const baseX = i % 2 === 0 ? 20 : width - 20;
+    const baseY = i < 2 ? 24 : height - 24;
+    ctx.beginPath();
+    ctx.moveTo(baseX, baseY);
+    ctx.lineTo(baseX + (i % 2 === 0 ? 36 : -36), baseY + (i < 2 ? 28 : -28));
+    ctx.stroke();
+    ctx.beginPath();
+    ctx.moveTo(baseX, baseY);
+    ctx.lineTo(baseX + (i % 2 === 0 ? 26 : -26), baseY + (i < 2 ? 42 : -42));
+    ctx.stroke();
+  }
+  ctx.restore();
+}
+
+function drawPanelVignette(ctx, width, height) {
+  ctx.save();
+  const gradient = ctx.createRadialGradient(
+    width / 2,
+    height / 2,
+    Math.min(width, height) * 0.45,
+    width / 2,
+    height / 2,
+    Math.max(width, height) * 0.8
+  );
+  gradient.addColorStop(0, setAlpha("#000000", 0));
+  gradient.addColorStop(1, setAlpha("#000000", 0.38));
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, width, height);
+  ctx.restore();
+
+  ctx.save();
+  ctx.globalAlpha = 0.14;
+  ctx.strokeStyle = setAlpha("#050209", 0.3);
+  ctx.lineWidth = 2;
+  const hatchSpacing = 36;
+  for (let x = -width; x < width * 2; x += hatchSpacing) {
+    ctx.beginPath();
+    ctx.moveTo(x, -10);
+    ctx.lineTo(x + hatchSpacing * 0.6, height + 10);
+    ctx.stroke();
+  }
+  ctx.restore();
+}
+
+function drawSpeechBubble(ctx, metrics, hero, width, height, artFrame) {
+  const presetLine = hero.presetBubble?.trim();
   const powerLine = hero.power?.trim();
   const backstoryLine = hero.backstory
     ?.split(/[\n\.\!\?]/)
@@ -1531,7 +2791,7 @@ function drawSpeechBubble(ctx, metrics, hero, width, height) {
     : hero.alignment === "Anti-hero"
     ? "DON'T MISTAKE ME FOR A SAVIOR!"
     : "UPHOLDING JUSTICE!";
-  const rawMessage = powerLine || backstoryLine || fallback;
+  const rawMessage = presetLine || powerLine || backstoryLine || fallback;
   if (!rawMessage) {
     return;
   }
@@ -1542,19 +2802,34 @@ function drawSpeechBubble(ctx, metrics, hero, width, height) {
   const maxBubbleWidth = width * 0.72;
   const lines = wrapText(ctx, message, maxBubbleWidth - 48);
   const measured = lines.map((line) => ctx.measureText(line).width);
+  const bubbleGuide = artFrame && hero.heroArt?.bubble ? hero.heroArt.bubble : null;
+  const computedWidth = Math.max(width * 0.38, Math.max(...measured) + 36);
   const bubbleWidth = Math.min(
     maxBubbleWidth,
-    Math.max(width * 0.38, Math.max(...measured) + 36)
+    bubbleGuide ? width * clamp(bubbleGuide.widthRatio ?? 0.5, 0.3, 0.78) : computedWidth
   );
-  const bubbleHeight = lines.length * 22 + 34;
-  const bubbleX = Math.max(20, width * 0.08);
-  const bubbleY = clamp(
+  let bubbleX = Math.max(20, width * 0.08);
+  let bubbleY = clamp(
     metrics.topY - metrics.figureHeight * 0.24,
     18,
     height * 0.45
   );
-  const tailX = clamp(metrics.centerX - metrics.shoulderWidth * 0.12, bubbleX + 24, bubbleX + bubbleWidth - 24);
-  const tailY = metrics.eyeY + metrics.headHeight * 0.25;
+  let tailX = clamp(
+    metrics.centerX - metrics.shoulderWidth * 0.12,
+    bubbleX + 24,
+    bubbleX + bubbleWidth - 24
+  );
+  let tailY = metrics.eyeY + metrics.headHeight * 0.25;
+  if (bubbleGuide) {
+    const anchorX = clamp(bubbleGuide.anchorX ?? 0.76, 0.12, 0.92);
+    const anchorY = clamp(bubbleGuide.anchorY ?? 0.12, 0.02, 0.6);
+    const centerX = width * anchorX;
+    bubbleX = clamp(centerX - bubbleWidth / 2, 18, width - bubbleWidth - 18);
+    bubbleY = clamp(height * anchorY, 14, height * 0.55);
+    tailX = clamp(width * (bubbleGuide.tailX ?? anchorX), bubbleX + 24, bubbleX + bubbleWidth - 24);
+    tailY = clamp(height * (bubbleGuide.tailY ?? (anchorY + 0.18)), bubbleY + 24, bubbleY + 260);
+  }
+  const bubbleHeight = lines.length * 22 + 34;
 
   ctx.beginPath();
   ctx.moveTo(bubbleX + 18, bubbleY);
@@ -1629,7 +2904,7 @@ function drawSpeechBubble(ctx, metrics, hero, width, height) {
   ctx.restore();
 }
 
-function drawActionBurst(ctx, metrics, hero) {
+function drawActionBurst(ctx, metrics, hero, artFrame) {
   const specialtyWords = {
     Mystic: "ARCANA!",
     Speedster: "ZOOM!",
@@ -1644,16 +2919,23 @@ function drawActionBurst(ctx, metrics, hero) {
     "Anti-hero": "BAM!",
     Vigilante: "THWACK!",
   };
-  const text = (specialtyWords[hero.specialty] || alignmentWords[hero.alignment] || "POW!").toUpperCase();
+  const burst = hero.presetSfx || specialtyWords[hero.specialty] || alignmentWords[hero.alignment] || "POW!";
+  const text = burst.toUpperCase();
 
   ctx.save();
-  ctx.translate(
-    metrics.centerX + metrics.shoulderWidth * 1.05,
-    metrics.baseY - metrics.figureHeight * 0.62
-  );
-  ctx.rotate(-0.1);
+  const sfxGuide = artFrame && hero.heroArt?.sfx ? hero.heroArt.sfx : null;
+  const burstX = sfxGuide
+    ? canvas.width * clamp(sfxGuide.anchorX ?? 0.24, 0.05, 0.95)
+    : metrics.centerX + metrics.shoulderWidth * 1.05;
+  const burstY = sfxGuide
+    ? canvas.height * clamp(sfxGuide.anchorY ?? 0.24, 0.05, 0.92)
+    : metrics.baseY - metrics.figureHeight * 0.62;
+  ctx.translate(burstX, burstY);
+  ctx.rotate(sfxGuide ? sfxGuide.rotation ?? -0.16 : -0.1);
   const spikes = 16;
-  const radius = metrics.figureHeight * 0.22;
+  const radius = sfxGuide
+    ? Math.max(artFrame.width, artFrame.height) * clamp(sfxGuide.radiusRatio ?? 0.2, 0.12, 0.32)
+    : metrics.figureHeight * 0.22;
   ctx.beginPath();
   for (let i = 0; i < spikes; i++) {
     const angle = (Math.PI * 2 * i) / spikes;
@@ -1680,6 +2962,32 @@ function drawActionBurst(ctx, metrics, hero) {
   ctx.textBaseline = "middle";
   ctx.fillText(text, 0, 0);
   ctx.restore();
+}
+
+function drawCrosshatchTexture(ctx, x, y, width, height, options = {}) {
+  const spacing = Math.max(4, options.spacing || 12);
+  const angle = options.angle ?? Math.PI / 4;
+  const weight = options.weight || 1;
+  const alpha = options.alpha ?? 0.2;
+  const passes = options.passes || 2;
+  const color = options.color || "#050209";
+
+  const maxDistance = width + height;
+  for (let pass = 0; pass < passes; pass++) {
+    const rotation = pass % 2 === 0 ? angle : -angle;
+    ctx.save();
+    ctx.translate(x + width / 2, y + height / 2);
+    ctx.rotate(rotation);
+    ctx.beginPath();
+    for (let i = -maxDistance; i <= maxDistance; i += spacing) {
+      ctx.moveTo(i, -maxDistance);
+      ctx.lineTo(i, maxDistance);
+    }
+    ctx.strokeStyle = setAlpha(color, alpha);
+    ctx.lineWidth = weight;
+    ctx.stroke();
+    ctx.restore();
+  }
 }
 
 function wrapText(ctx, text, maxWidth) {
@@ -1778,4 +3086,4 @@ function capitalizeSentences(text) {
 }
 
 // Render initial hero using default form selections
-form.dispatchEvent(new Event("submit", { cancelable: true }));
+renderHero();

--- a/styles.css
+++ b/styles.css
@@ -83,6 +83,10 @@ body {
   font-size: 0.95rem;
 }
 
+.preset-field {
+  margin-bottom: 1.2rem;
+}
+
 .field span,
 .field-label {
   font-weight: 600;
@@ -199,6 +203,14 @@ textarea {
   font-size: 1.4rem;
   color: #fdea55;
   letter-spacing: 1px;
+}
+
+.sheet-theme {
+  margin: 0;
+  font-size: 0.95rem;
+  letter-spacing: 1.4px;
+  text-transform: uppercase;
+  color: rgba(255, 236, 141, 0.82);
 }
 
 .character-sheet p {


### PR DESCRIPTION
## Summary
- add bespoke SVG hero illustrations for each preset so the panel reads like inked comic art
- preload and render preset hero artwork on the canvas, reserving the procedural figure only as a fallback when no asset is available
- adapt speech bubble, action burst, and shadow placement to follow art-specific layout guides and show an inking placeholder while assets load

## Testing
- `node -e "new Function(require('fs').readFileSync('script.js','utf8'));"`


------
https://chatgpt.com/codex/tasks/task_e_68e2d156d7f48323b780348729a23690